### PR TITLE
選択解除したタブを再度選択する時に元の位置を選択していたのをなおした

### DIFF
--- a/sort.js
+++ b/sort.js
@@ -22,6 +22,7 @@ window.onload = function () {
         data.item(i).innerText = d;
     });
 
-    div.innerHTML = a.innerText;
-    div.classList.add('hdtb-msel');
+    var selectTab = document.querySelector('a.q.qs[href=""]').parentNode;
+    selectTab.classList.add('hdtb-msel');
+    selectTab.innerHTML = selectTab.innerText;
 };


### PR DESCRIPTION
位置を入れ替えるのではなく、単純にhrefと文字を書き換えているので元のDOMを選択状態にするとこうなる
